### PR TITLE
[conf]Removed non-ASCII characters, fixes issue #8

### DIFF
--- a/msg/SbgEkfNav.msg
+++ b/msg/SbgEkfNav.msg
@@ -8,13 +8,13 @@ uint32 time_stamp
 # Velocity (North, East, Down) direction m/s
 geometry_msgs/Vector3 velocity
 
-# 1 σ Velocity in (North, East, Down) direction accuracy m/s
+# 1 sigma Velocity in (North, East, Down) direction accuracy m/s
 geometry_msgs/Vector3 velocity_accuracy
 
 # [Latitude (deg), Longitude (deg), Altitude (above Mean Sea Level in meters)] 
 geometry_msgs/Vector3 position
 
-# Altitude difference between the geoid and the Ellipsoid (WGS-84 Altitude – MSL Altitude)
+# Altitude difference between the geoid and the Ellipsoid (WGS-84 Altitude - MSL Altitude)
 # (Height above Ellipsoid = altitude + undulation)
 float32 undulation
 

--- a/msg/SbgEkfQuat.msg
+++ b/msg/SbgEkfQuat.msg
@@ -2,7 +2,7 @@
 
 Header header
 
-#  Time since sensor is powered up μs 
+#  Time since sensor is powered up us 
 uint32 time_stamp
 
 #  Quaternion parameter (ROS order X, Y, Z, W)

--- a/msg/SbgEvent.msg
+++ b/msg/SbgEvent.msg
@@ -1,7 +1,7 @@
 # SBG Ellipse Messages
 Header header
 
-# Time since sensor is powered up μs 
+# Time since sensor is powered up us 
 uint32 time_stamp
 
 # True if we have received events at a higher rate than 1 kHz.

--- a/msg/SbgGpsHdt.msg
+++ b/msg/SbgGpsHdt.msg
@@ -1,7 +1,7 @@
 # SBG Ellipse Messages
 Header header
 
-# Time since sensor is powered up μs 
+# Time since sensor is powered up us 
 uint32 time_stamp
 
 # GPS True Heading status.
@@ -17,11 +17,11 @@ uint32 tow
 # True heading angle (0 to 360 deg).
 float32 true_heading
 
-# 1 σ True heading estimated accuracy (0 to 360 deg).
+# 1 sigma True heading estimated accuracy (0 to 360 deg).
 float32 true_heading_acc
 
 # Pitch angle from the master to the rover
 float32 pitch
 
-# 1 σ pitch estimated accuracy
+# 1 sigma pitch estimated accuracy
 float32 pitch_acc

--- a/msg/SbgGpsPos.msg
+++ b/msg/SbgGpsPos.msg
@@ -1,7 +1,7 @@
 # SBG Ellipse Messages
 Header header
 
-#  Time since sensor is powered up μs 
+#  Time since sensor is powered up us 
 uint32 time_stamp
 
 # GPS position fix and status bitmask
@@ -13,7 +13,7 @@ uint32 gps_tow
 # [Latitude (positive North deg), Longitude (positive East deg), Altitude (Above Mean Sea Level m)]
 geometry_msgs/Vector3 position
 
-# Altitude difference between the geoid and the Ellipsoid (WGS-84 Altitude – MSL Altitude)
+# Altitude difference between the geoid and the Ellipsoid (WGS-84 Altitude - MSL Altitude)
 # (Height above Ellipsoid = altitude + undulation)
 float32 undulation
 

--- a/msg/SbgGpsVel.msg
+++ b/msg/SbgGpsVel.msg
@@ -1,7 +1,7 @@
 # SBG Ellipse Messages
 Header header
 
-#  Time since sensor is powered up μs 
+#  Time since sensor is powered up us 
 uint32 time_stamp
 
 # GPS velocity fix and status bitmask - 

--- a/msg/SbgImuData.msg
+++ b/msg/SbgImuData.msg
@@ -1,23 +1,23 @@
 # SBG Ellipse Messages
 Header header
 
-# Time since sensor is powered up μs 
+# Time since sensor is powered up us 
 uint32 time_stamp
 
 # IMU Status
 SbgImuStatus imu_status
 
-# Filtered Accelerometer – X, Y, Z axis m/s2 
+# Filtered Accelerometer - X, Y, Z axis m/s2 
 geometry_msgs/Vector3 accel
 
-# Filtered Gyroscope – X, Y, Z axis rad/s 
+# Filtered Gyroscope - X, Y, Z axis rad/s 
 geometry_msgs/Vector3 gyro
 
 # Internal Temperature degC 
 float32 temp
 
-# Sculling output – X, Y, Z axis m/s2 
+# Sculling output - X, Y, Z axis m/s2 
 geometry_msgs/Vector3 delta_vel
 
-# Coning output – X, Y, Z axis rad/s 
+# Coning output - X, Y, Z axis rad/s 
 geometry_msgs/Vector3 delta_angle

--- a/msg/SbgOdoVel.msg
+++ b/msg/SbgOdoVel.msg
@@ -1,7 +1,7 @@
 # SBG Ellipse Messages
 Header header
 
-# Time since sensor is powered up μs 
+# Time since sensor is powered up us 
 uint32 time_stamp
 
 # Real Measurement

--- a/msg/SbgPressure.msg
+++ b/msg/SbgPressure.msg
@@ -1,7 +1,7 @@
 # SBG Ellipse Messages
 Header header
 
-# Time since sensor is powered up μs 
+# Time since sensor is powered up us 
 uint32 time_stamp
 
 # Pressure status (True if the altimeter equipment was correctly initialized)

--- a/msg/SbgShipMotion.msg
+++ b/msg/SbgShipMotion.msg
@@ -1,7 +1,7 @@
 # SBG Ellipse Messages
 Header header
 
-# Time since sensor is powered up μs 
+# Time since sensor is powered up us 
 uint32 time_stamp
 
 # Main heave period in seconds. s float 4 4

--- a/msg/SbgUtcTime.msg
+++ b/msg/SbgUtcTime.msg
@@ -1,7 +1,7 @@
 # SBG Ellipse Messages
 Header header
 
-# Time since sensor is powered up (µs)
+# Time since sensor is powered up (us)
 uint32 time_stamp
 
 # General UTC time and clock sync status


### PR DESCRIPTION
Removed all non-ASCII characters which prevented the use of filters when replaying rosbags.